### PR TITLE
Adding code of conduct

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,9 @@
+<footer>
+	<div class="divider black">
+		<div class="connect-text">
+			<ul>
+				<li><a href="{{ site.baseurl }}/code-of-conduct">Code Of Conduct</a></li>
+			</ul>
+		</div>
+	</div>
+</footer>

--- a/_layouts/code-of-conduct.html
+++ b/_layouts/code-of-conduct.html
@@ -11,3 +11,5 @@ layout: default
 		</div>
 	</div>
 </section>
+
+{% include footer.html %}

--- a/_layouts/code-of-conduct.html
+++ b/_layouts/code-of-conduct.html
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+
+<section class="copy top-offset connect">
+	<div class="connect-text">
+		<h1>{{ page.title }}</h1>
+
+		<div class="content">
+			{{ content }}
+		</div>
+	</div>
+</section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,15 +28,15 @@
 	<header class="header">
 		<nav>
 			<ul class="nav">
-				<li><a href="#about">About</a></li>
-				<li><a href="#location">Location</a></li>
-				<li><a href="#cfp">Call for proposals</a></li>
-				<li><a href="#talks">Talks</a></li>
+				<li><a href="{{ site.baseurl }}/#about">About</a></li>
+				<li><a href="{{ site.baseurl }}/#location">Location</a></li>
+				<li><a href="{{ site.baseurl }}/#cfp">Call for proposals</a></li>
+				<li><a href="{{ site.baseurl }}/#talks">Talks</a></li>
 
-				<li><a href="#tickets">Tickets</a></li>
-				<li><a href="#partners">Partners</a></li>
-				<li><a href="#team">Team</a></li>
-				<li><a href="#contact">Contact</a></li>
+				<li><a href="{{ site.baseurl }}/#tickets">Tickets</a></li>
+				<li><a href="{{ site.baseurl }}/#partners">Partners</a></li>
+				<li><a href="{{ site.baseurl }}/#team">Team</a></li>
+				<li><a href="{{ site.baseurl }}/#contact">Contact</a></li>
 
 			</ul>
 		</nav> 

--- a/_posts/2015-02-11-code-of-conduct.markdown
+++ b/_posts/2015-02-11-code-of-conduct.markdown
@@ -4,7 +4,7 @@ category: Code of Conduct
 permalink: code-of-conduct
 ---
 
-Webcamp Ljubljana code of conduct __tl;dr__:
+Webcamp Ljubljana Code of Conduct __tl;dr__:
 
 >Be respectful of other people, respectfully ask people to stop if you are bothered, 
 and if you can't resolve an issue contact staff. If you are being a problem, it will be apparent and you'll be asked to leave.

--- a/_posts/2015-02-11-code-of-conduct.markdown
+++ b/_posts/2015-02-11-code-of-conduct.markdown
@@ -1,0 +1,79 @@
+---
+layout: code-of-conduct
+category: Code of Conduct
+permalink: code-of-conduct
+---
+
+Webcamp Ljubljana code of conduct __tl;dr__:
+
+>Be respectful of other people, respectfully ask people to stop if you are bothered, 
+and if you can't resolve an issue contact staff. If you are being a problem, it will be apparent and you'll be asked to leave.
+
+##Respect
+
+Webcamp Ljubljana is an positive community that recognizes and celebrates the creativity and collaboration of creators and the diversity of people, cultures, and opinions that they bring to Webcamp Ljubljana.
+
+Webcamp Ljubljana events are an inclusive environment, based on treating all individuals respectfully, regardless of gender (including transgender status), sexual orientation, age, disability, medical conditions, nationality, ethnicity, religion (or lack thereof), or software preferences.
+
+We value respectful behavior above individual opinions.
+
+Respectful behavior includes:
+
+* Be considerate, kind, constructive, and helpful. 
+* Avoid demeaning, discriminatory, harassing, hateful, or physically threatening behavior, speech, and imagery. 
+* If you're not sure, ask someone instead of assuming.
+
+##Resolve Peacefully
+
+We believe peer to peer discussions, feedback, corrections can help build a stronger, safer, and more welcoming community.
+
+If you see someone behaving disrespectfully, you are encouraged to respectfully discourage them from such behavior. Expect that others in the community wish to help keep the community respectful and welcome your input in doing so.
+
+If you experience disrespectful behavior and feel in any way unable to respond or resolve it respectfully (for any reason), please immediately bring it to the attention of an organizer. We want to hear from you about anything that you feel is disrespectful, threatening, or just icky in any way. We will listen and work to resolve the matter.
+
+##Apologize for Mistakes
+
+Should you catch yourself behaving disrespectfully, or be confronted as such, own up to your words and actions, and apologize accordingly. No one is perfect, and even well-intentioned people make mistakes. What matters is how you handle them, and avoiding repeating them in the future.
+
+##Contact Information
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff. Their names are found here under __Signed__ section, they will be circulating in the crowd, 
+and are easy to find. 
+
+If the matter is especially urgent, please call/contact any of these individuals:
+
+Jure Čuhalev at +386 41 893 765 
+
+Conference staff will be happy to help participants contact local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+
+##Consequences
+
+If the organizers determine that an event participant is behaving disrespectfully, the organizers may take any action they deem appropriate, up to and including expulsion and exclusion from the event.
+
+As organizers, we will seek to resolve conflicts peacefully and in a manner that is positive for the community. We can't foresee every situation however, and thus if in the organizers' judgment the best thing to do is to ask a disrespectful individual to leave, we will do so. We've never had to do so; please don't be the first.
+
+##Licence
+This Code of Conduct was forked from the example policy from the [IndieWebCamp.com](http://indiewebcamp.com/code-of-conduct), which is under a Creative Commons Zero license.
+
+Creative Commons License 
+
+<img src="http://i.creativecommons.org/l/by/3.0/88x31.png" alt="Creative Commons License" style="border-width: 0;">
+
+Conference [Code of Conduct](http://2015.webcamp.si/code-of-conduct/) is licensed under a [Creative Commons 
+Attribution 4.0 Unported License](https://creativecommons.org/licenses/by/4.0/).
+
+##Thanks
+
+Thank you to every Webcamp Ljubljana community member for helping making Webcamp Ljubljana the respectful and inclusive community that it is.
+
+##Signed
+
+Organizers:
+
+* Mojca Berce
+* Marko Brumen
+* Maša Černovšek Logar
+* Jure Čuhalev
+* Heidi Pungartnik
+* Klemen Robnik
+* Tina Rozman
+* Nataša Šubelj

--- a/_posts/2015-02-11-code-of-conduct.markdown
+++ b/_posts/2015-02-11-code-of-conduct.markdown
@@ -39,7 +39,7 @@ Should you catch yourself behaving disrespectfully, or be confronted as such, ow
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff. Their names are found here under __Signed__ section, they will be circulating in the crowd, 
 and are easy to find. 
 
-If the matter is especially urgent, please call/contact any of these individuals:
+If the matter is especially urgent, please call/contact:
 
 Jure Čuhalev at +386 41 893 765 
 

--- a/assets/stylesheet/_sass/_copy.scss
+++ b/assets/stylesheet/_sass/_copy.scss
@@ -1,0 +1,16 @@
+blockquote {
+	background-color: #efefef;
+	padding: 15px 35px;
+	margin-left: 0;
+	margin-right: 0;
+	font-style: italic;
+	line-height: 2;
+}
+
+.top-offset {
+	padding-top: 60px;
+}
+
+.content{
+	line-height: 2;
+}

--- a/assets/stylesheet/_sass/_default.scss
+++ b/assets/stylesheet/_sass/_default.scss
@@ -9,6 +9,10 @@ Default style
 }
 
 body {
+	/* remove default margin and padding of some browsers */
+	margin: 0;
+	padding: 0;
+
 	overflow-x: hidden;
 	font: {
 		size: 100%;

--- a/assets/stylesheet/_sass/all.scss
+++ b/assets/stylesheet/_sass/all.scss
@@ -11,3 +11,4 @@
 @import "sponsors";
 @import "connect";
 @import "blog";
+@import "copy";

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ title: WebCamp Ljubljana 2015
 		Topics that will be covered are: <b>Front end</b>, <b>Back end</b> and <b>DevOps</b>.
 
 		<br /><br />
-		<a href="{{ site.baseurl }}/code-of-conduct" target="_blank">Code of conduct</a>
+		<a href="{{ site.baseurl }}/code-of-conduct" target="_blank">Code of Conduct</a>
 
 	</p>
 </div>
@@ -228,13 +228,6 @@ title: WebCamp Ljubljana 2015
 	<div class="connect-div"></div>
 </div>
 
-<footer>
-	<div class="divider black">
-		<div class="connect-text">
-			<ul>
-				<li><a href="{{ site.baseurl }}/code-of-conduct">Code Of Conduct</a></li>
-			</ul>
-		</div>
-	</div>
-</footer>
+{% include footer.html %}
+
 </main>

--- a/index.html
+++ b/index.html
@@ -226,6 +226,11 @@ title: WebCamp Ljubljana 2015
 
 <footer>
 	<div class="divider black">
+		<div class="connect-text">
+			<ul>
+				<li><a href="{{ site.baseurl }}/code-of-conduct">Code Of Conduct</a></li>
+			</ul>
+		</div>
 	</div>
 </footer>
 </main>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@ title: WebCamp Ljubljana 2015
 		It is a volunteer event organized <b>by community for the community</b>. We expect over 300 attendees from Slovenia and neighbouring countries which is why the event will be held in English.
 		<br /><br />
 		Topics that will be covered are: <b>Front end</b>, <b>Back end</b> and <b>DevOps</b>.
+
+		<br /><br />
+		<a href="{{ site.baseurl }}/code-of-conduct" target="_blank">Code of conduct</a>
+
 	</p>
 </div>
 


### PR DESCRIPTION
In addition to adding code of conduct I also:
- introduced basic reset for CSS (eg. removed default paddings and margins)
- extracted footer in order to be able to use it on other sub pages
- expanded the use of navigational links, also in order to be able to use it on sub pages
- added some styling which is (for now) used only on the code of conduct page, but is intended to carry the styling of all the potential sub pages

Before merging would be nice to review the signed members of the code of conduct and added/changed info of the go to people in case of harassment.
